### PR TITLE
Use query parameters on GET requests (fixes issue #3)

### DIFF
--- a/lib/taxjar.js
+++ b/lib/taxjar.js
@@ -39,7 +39,7 @@ Taxjar.prototype = {
     return this.request.api({
       method: 'get',
       url: '/v2/rates/' + zip,
-      data: params
+      query: params
     });
   },
 
@@ -55,7 +55,7 @@ Taxjar.prototype = {
     return this.request.api({
       method: 'get',
       url: '/v2/transactions/orders',
-      data: params
+      query: params
     });
   },
 
@@ -93,7 +93,7 @@ Taxjar.prototype = {
     return this.request.api({
       method: 'get',
       url: '/v2/transactions/refunds',
-      data: params
+      query: params
     });
   },
 
@@ -131,7 +131,7 @@ Taxjar.prototype = {
     return this.request.api({
       method: 'get',
       url: '/v2/validation',
-      data: params
+      query: params
     });
   },
   

--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -17,7 +17,8 @@ Request.prototype = {
     rest[options.method](this._taxjar.getApiConfig('host') + options.url, {
       accessToken: this._taxjar.getApiConfig('key'),
       headers: options.headers,
-      data: JSON.stringify(options.data)
+      data: JSON.stringify(options.data),
+      query: options.query
     }).on('complete', function(result) {
       if (result instanceof Error) {
         defer.reject(result);


### PR DESCRIPTION
Fixes issue #3, uses query parameters instead of body parameters for GET-based requests.