### PR TITLE
fixed Promise.defer() deprecated, fixes issue #6

### DIFF
--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -9,25 +9,25 @@ function Request(taxjar) {
 
 Request.prototype = {
   api: function(options) {
-    var defer = Promise.defer();
+    var self = this;
 
-    options.headers = options.headers || {};
-    options.headers['Content-Type'] = 'application/json';
+    return new Promise(function(resolve, reject) {
+      options.headers = options.headers || {};
+      options.headers['Content-Type'] = 'application/json';
 
-    rest[options.method](this._taxjar.getApiConfig('host') + options.url, {
-      accessToken: this._taxjar.getApiConfig('key'),
-      headers: options.headers,
-      data: JSON.stringify(options.data),
-      query: options.query
-    }).on('complete', function(result) {
-      if (result.error) {
-        defer.reject(result);
-      } else {
-        defer.resolve(result);
-      }
+      rest[options.method](self._taxjar.getApiConfig('host') + options.url, {
+        accessToken: self._taxjar.getApiConfig('key'),
+        headers: options.headers,
+        data: JSON.stringify(options.data),
+        query: options.query
+      }).on('complete', function(result) {
+        if (result.error){
+          reject(result);
+        } else {
+          resolve(result);
+        }
+      });
     });
-
-    return defer.promise;
   }
 };
 


### PR DESCRIPTION
Defer is deprecated as stated by Mozilla 

https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Deferred


