### PR TITLE
Address Validation

### DIFF
--- a/lib/taxjar.ts
+++ b/lib/taxjar.ts
@@ -187,6 +187,14 @@ class Taxjar {
     });
   }
 
+  validateAddress(params: TaxjarTypes.AddressParams): Promise<any> {
+    return this.request.api({
+      method: 'POST',
+      url: 'addresses/validate',
+      data: params
+    });
+  }
+
   validate(params: TaxjarTypes.ValidateParams): Promise<any> {
     return this.request.api({
       method: 'GET',

--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -138,6 +138,14 @@ export namespace TaxjarTypes {
     street?: string
   }
 
+  export interface AddressParams {
+    country?: string,
+    state?: string,
+    zip?: string,
+    city?: string,
+    street?: string
+  }
+
   export interface ValidateParams {
     vat: string
   }

--- a/test/mocks/validations.js
+++ b/test/mocks/validations.js
@@ -4,6 +4,18 @@ const nock = require('nock');
 
 const TEST_API_HOST = 'https://mockapi.taxjar.com';
 
+const ADDRESS_VALIDATION_RES = {
+  "addresses": [
+    {
+      "zip": "85297-2176",
+      "street": "3301 S Greenfield Rd",
+      "state": "AZ",
+      "country": "US",
+      "city": "Gilbert"
+    }
+  ]
+};
+
 const VALIDATION_RES = {
   "validation": {
     "valid": true,
@@ -22,10 +34,22 @@ const VALIDATION_RES = {
 
 nock(TEST_API_HOST)
   .matchHeader('Authorization', /Bearer.*/)
+  .post('/v2/addresses/validate', {
+    country: 'US',
+    state: 'AZ',
+    zip: '85297',
+    city: 'Gilbert',
+    street: '3301 South Greenfield Rd'
+  })
+  .reply(200, ADDRESS_VALIDATION_RES);
+
+nock(TEST_API_HOST)
+  .matchHeader('Authorization', /Bearer.*/)
   .get('/v2/validation')
   .query({
     vat: 'FR40303265045'
   })
   .reply(200, VALIDATION_RES);
 
+module.exports.ADDRESS_VALIDATION_RES = ADDRESS_VALIDATION_RES;
 module.exports.VALIDATION_RES = VALIDATION_RES;

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -673,6 +673,35 @@ describe('TaxJar API', () => {
 
   describe('validations', () => {
 
+    it('validates an address', (done) => {
+      taxjarClient.validateAddress({
+        country: 'US',
+        state: 'AZ',
+        zip: '85297',
+        city: 'Gilbert',
+        street: '3301 South Greenfield Rd'
+      }).then(res => {
+        assert.deepEqual(res, validationMock.ADDRESS_VALIDATION_RES);
+        done();
+      });
+    });
+
+    if (process.env.TAXJAR_API_URL) {
+      it('returns successful response in sandbox', (done) => {
+        taxjarClient.setApiConfig('apiUrl', process.env.TAXJAR_API_URL);
+        taxjarClient.validateAddress({
+          country: 'US',
+          state: 'AZ',
+          zip: '85297',
+          city: 'Gilbert',
+          street: '3301 South Greenfield Rd'
+        }).then(res => {
+          assert.isOk(res.validation);
+          done();
+        });
+      }).timeout(5000);
+    }
+
     it('validates a VAT number', (done) => {
       taxjarClient.validate({
         vat: 'FR40303265045'


### PR DESCRIPTION
This PR adds support for TaxJar's address validation beta endpoint via `validateAddress`. At this time, address validation is only available for TaxJar Plus customers.