### PR TITLE
exempt_regions is not required

### DIFF
--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -129,7 +129,7 @@ export namespace TaxjarTypes {
   export interface CustomerParams {
     customer_id: string,
     exemption_type: string,
-    exempt_regions: object,
+    exempt_regions?: object,
     name: string,
     country?: string,
     state?: string,


### PR DESCRIPTION
The api docs say this field is optional and API requests seem to work without it. 