### PR TITLE
Exclude unnecessary files in npm package; closes #24

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-.vscode/
-lib/
-test/
-.gitignore
-.npmignore
-.DS_Store

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "node": ">= 4"
   },
   "main": "dist/taxjar.js",
+  "files": ["dist/**"],
   "types": "dist/taxjar.d.ts",
   "devDependencies": {
     "chai": "~3.5.0",


### PR DESCRIPTION
This PR moves from an _exclusion_ strategy ([`.npmignore`](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package)) by listing files that _shouldn't be included_ in the npm package to an _inclusion_ strategy ([`package.json` `files` field](https://docs.npmjs.com/files/package.json#files)) by listing only the files that _should be included_ in the npm package.

The next time `tax-jar` is published, the following files will be removed from the published package:

- `.editorconfig`
- `.eslintrc`
- `.travis.yml`
- `tsconfig.json`

And the package will include only:

- all the contents of `dist/`
- `package.json`
- `LICENSE`
- `README`

Further, this should prevent future configuration/other files that may be included in the project from unnecessarily being included in the published package and reduce package size for developers or integrations installing the npm package going forward.

See #24 for more.