### PR TITLE
Add nested types (e.g., line_items) for IntelliSense

### DIFF
--- a/lib/taxjar.ts
+++ b/lib/taxjar.ts
@@ -142,11 +142,10 @@ class Taxjar {
     });
   }
 
-  listCustomers(params?: object): Promise<any> {
+  listCustomers(): Promise<any> {
     return this.request.api({
       method: 'GET',
-      url: 'customers',
-      query: params
+      url: 'customers'
     });
   }
 

--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -20,6 +20,29 @@ export namespace TaxjarTypes {
     country?: string
   }
 
+  interface NexusAddress {
+    id?: string,
+    country?: string,
+    zip?: string,
+    state?: string,
+    city?: string,
+    street?: string
+  }
+
+  interface TaxLineItem {
+    id?: string,
+    quantity?: number,
+    product_tax_code?: string,
+    unit_price?: number,
+    discount?: number
+  }
+
+  interface LineItem extends TaxLineItem {
+    product_identifier?: string,
+    description?: string,
+    sales_tax?: number
+  }
+
   export interface TaxParams {
     from_country?: string,
     from_zip?: string,
@@ -34,8 +57,8 @@ export namespace TaxjarTypes {
     amount?: number,
     shipping: number,
     customer_id?: string,
-    nexus_addresses?: object,
-    line_items?: object
+    nexus_addresses?: NexusAddress[],
+    line_items?: TaxLineItem[]
   }
 
   export interface TransactionListParams {
@@ -61,7 +84,7 @@ export namespace TaxjarTypes {
     shipping: number,
     sales_tax: number,
     customer_id?: string,
-    line_items?: object
+    line_items?: LineItem[]
   }
 
   export interface UpdateOrderParams {
@@ -81,7 +104,7 @@ export namespace TaxjarTypes {
     shipping?: number,
     sales_tax?: number,
     customer_id?: string,
-    line_items?: object
+    line_items?: LineItem[]
   }
 
   export interface CreateRefundParams {
@@ -102,7 +125,7 @@ export namespace TaxjarTypes {
     shipping: number,
     sales_tax: number,
     customer_id?: string,
-    line_items?: object
+    line_items?: LineItem[]
   }
 
   export interface UpdateRefundParams {
@@ -123,13 +146,18 @@ export namespace TaxjarTypes {
     shipping?: number,
     sales_tax?: number,
     customer_id?: string,
-    line_items?: object
+    line_items?: LineItem[]
+  }
+
+  interface ExemptRegion {
+    country?: string,
+    state?: string
   }
 
   export interface CustomerParams {
     customer_id: string,
     exemption_type: string,
-    exempt_regions?: object,
+    exempt_regions?: ExemptRegion[],
     name: string,
     country?: string,
     state?: string,


### PR DESCRIPTION
This PR adds types to nested params for IntelliSense. In other words, when developers use the client API their experience is improved through tooltips showing hints for what items can or should be included when calling each method. Types were added for:

- [`v2/taxes`](https://developers.taxjar.com/api/reference/#post-calculate-sales-tax-for-an-order)
  - `nexus_addresses[]`
    - `id`
    - `country`
    - `zip`
    - `state`
    - `city`
    - `street`
  - `line_items[]`
    - `id`
    - `quantity`
    - `product_tax_code`
    - `unit_price`
    - `discount`
- [`v2/transactions/*`](https://developers.taxjar.com/api/reference/#transactions) (create and update)
  - `line_items[]`
    - `id`
    - `quantity`
    - `product_tax_code`
    - `unit_price`
    - `discount`
    - `product_identifier`
    - `description`
    - `sales_tax`
- [`v2/customers`](https://developers.taxjar.com/api/reference/#customers) (create and update)
  - `exempt_regions[]`
    - `country`
    - `state`

Also, query params for `listCustomers` is removed as the [API reference](https://developers.taxjar.com/api/reference/?javascript#customers) doesn't list any.