### PR TITLE
Add `provider` param to transaction methods

### DIFF
--- a/lib/taxjar.ts
+++ b/lib/taxjar.ts
@@ -74,10 +74,11 @@ class Taxjar {
     });
   }
 
-  showOrder(transactionId: string): Promise<any> {
+  showOrder(transactionId: string, params?: TaxjarTypes.TransactionShowParams): Promise<any> {
     return this.request.api({
       method: 'GET',
-      url: 'transactions/orders/' + transactionId
+      url: 'transactions/orders/' + transactionId,
+      query: params
     });
   }
 
@@ -97,10 +98,11 @@ class Taxjar {
     });
   }
 
-  deleteOrder(transactionId: string): Promise<any> {
+  deleteOrder(transactionId: string, params?: TaxjarTypes.TransactionDeleteParams): Promise<any> {
     return this.request.api({
       method: 'DELETE',
-      url: 'transactions/orders/' + transactionId
+      url: 'transactions/orders/' + transactionId,
+      query: params
     });
   }
 
@@ -112,10 +114,11 @@ class Taxjar {
     });
   }
 
-  showRefund(transactionId: string): Promise<any> {
+  showRefund(transactionId: string, params?: TaxjarTypes.TransactionShowParams): Promise<any> {
     return this.request.api({
       method: 'GET',
-      url: 'transactions/refunds/' + transactionId
+      url: 'transactions/refunds/' + transactionId,
+      query: params
     });
   }
 
@@ -135,10 +138,11 @@ class Taxjar {
     });
   }
 
-  deleteRefund(transactionId: string): Promise<any> {
+  deleteRefund(transactionId: string, params?: TaxjarTypes.TransactionDeleteParams): Promise<any> {
     return this.request.api({
       method: 'DELETE',
-      url: 'transactions/refunds/' + transactionId
+      url: 'transactions/refunds/' + transactionId,
+      query: params
     });
   }
 

--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -41,12 +41,20 @@ export namespace TaxjarTypes {
   export interface TransactionListParams {
     transaction_date?: string,
     from_transaction_date?: string,
-    to_transaction_date?: string
+    to_transaction_date?: string,
+    provider?: string
   }
+
+  export interface TransactionShowParams {
+    provider?: string
+  }
+
+  export interface TransactionDeleteParams extends TransactionShowParams {}
 
   export interface CreateOrderParams {
     transaction_id: string,
     transaction_date: string,
+    provider?: string,
     from_country?: string,
     from_zip?: string,
     from_state?: string,
@@ -88,6 +96,7 @@ export namespace TaxjarTypes {
     transaction_id: string,
     transaction_reference_id: string,
     transaction_date: string,
+    provider?: string,
     from_country?: string,
     from_zip?: string,
     from_state?: string,

--- a/test/mocks/orders.js
+++ b/test/mocks/orders.js
@@ -16,6 +16,7 @@ const SHOW_ORDER_RES = {
     "transaction_id": "123",
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
+    "provider": "api",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",
@@ -51,6 +52,7 @@ nock(TEST_API_HOST)
 nock(TEST_API_HOST)
   .matchHeader('Authorization', /Bearer.*/)
   .get('/v2/transactions/orders/' + SHOW_ORDER_RES.order.transaction_id)
+  .query(true)
   .reply(200, SHOW_ORDER_RES);
 
 nock(TEST_API_HOST)
@@ -68,6 +70,7 @@ nock(TEST_API_HOST)
 nock(TEST_API_HOST)
   .matchHeader('Authorization', /Bearer.*/)
   .delete('/v2/transactions/orders/' + DELETE_ORDER_RES.order.transaction_id)
+  .query(true)
   .reply(200, DELETE_ORDER_RES);
 
 module.exports.LIST_ORDER_RES = LIST_ORDER_RES;

--- a/test/mocks/refunds.js
+++ b/test/mocks/refunds.js
@@ -17,6 +17,7 @@ const SHOW_REFUND_RES = {
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
     "transaction_reference_id": "123",
+    "provider": "api",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",
@@ -52,6 +53,7 @@ nock(TEST_API_HOST)
 nock(TEST_API_HOST)
   .matchHeader('Authorization', /Bearer.*/)
   .get('/v2/transactions/refunds/' + SHOW_REFUND_RES.refund.transaction_id)
+  .query(true)
   .reply(200, SHOW_REFUND_RES);
 
 nock(TEST_API_HOST)
@@ -69,6 +71,7 @@ nock(TEST_API_HOST)
 nock(TEST_API_HOST)
   .matchHeader('Authorization', /Bearer.*/)
   .delete('/v2/transactions/refunds/' + DELETE_REFUND_RES.refund.transaction_id)
+  .query(true)
   .reply(200, DELETE_REFUND_RES);
 
 module.exports.LIST_REFUND_RES = LIST_REFUND_RES;

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -176,7 +176,8 @@ describe('TaxJar API', () => {
     it('lists order transactions', (done) => {
       taxjarClient.listOrders({
         'from_transaction_date': '2015/05/01',
-        'to_transaction_date': '2015/05/31'
+        'to_transaction_date': '2015/05/31',
+        'provider': 'api'
       }).then(res => {
         assert.deepEqual(res, orderMock.LIST_ORDER_RES);
         done();
@@ -188,7 +189,8 @@ describe('TaxJar API', () => {
         taxjarClient.setApiConfig('apiUrl', process.env.TAXJAR_API_URL);
         taxjarClient.listOrders({
           'from_transaction_date': '2015/05/01',
-          'to_transaction_date': '2015/05/31'
+          'to_transaction_date': '2015/05/31',
+          'provider': 'api'
         }).then(res => {
           assert.isOk(res.orders);
           done();
@@ -197,7 +199,7 @@ describe('TaxJar API', () => {
     }
 
     it('shows an order transaction', (done) => {
-      taxjarClient.showOrder('123').then(res => {
+      taxjarClient.showOrder('123', {provider: 'api'}).then(res => {
         assert.deepEqual(res, orderMock.SHOW_ORDER_RES);
         done();
       });
@@ -206,7 +208,7 @@ describe('TaxJar API', () => {
     if (process.env.TAXJAR_API_URL) {
       it('showOrder returns successful response in sandbox', (done) => {
         taxjarClient.setApiConfig('apiUrl', process.env.TAXJAR_API_URL);
-        taxjarClient.showOrder('123').then(res => {
+        taxjarClient.showOrder('123', {provider: 'api'}).then(res => {
           assert.isOk(res.order);
           done();
         });
@@ -217,6 +219,7 @@ describe('TaxJar API', () => {
       taxjarClient.createOrder({
         'transaction_id': '123',
         'transaction_date': '2015/05/14',
+        'provider': 'api',
         'to_country': 'US',
         'to_zip': '90002',
         'to_state': 'CA',
@@ -246,6 +249,7 @@ describe('TaxJar API', () => {
         taxjarClient.createOrder({
           'transaction_id': '123',
           'transaction_date': '2015/05/14',
+          'provider': 'api',
           'to_country': 'US',
           'to_zip': '90002',
           'to_state': 'CA',
@@ -316,7 +320,7 @@ describe('TaxJar API', () => {
     }
 
     it('deletes an order transaction', (done) => {
-      taxjarClient.deleteOrder('123').then(res => {
+      taxjarClient.deleteOrder('123', {provider: 'api'}).then(res => {
         assert.deepEqual(res, orderMock.DELETE_ORDER_RES);
         done();
       });
@@ -325,7 +329,7 @@ describe('TaxJar API', () => {
     if (process.env.TAXJAR_API_URL) {
       it('deleteOrder returns successful response in sandbox', (done) => {
         taxjarClient.setApiConfig('apiUrl', process.env.TAXJAR_API_URL);
-        taxjarClient.deleteOrder('123').then(res => {
+        taxjarClient.deleteOrder('123', {provider: 'api'}).then(res => {
           assert.isOk(res.order);
           done();
         });
@@ -335,7 +339,8 @@ describe('TaxJar API', () => {
     it('lists refund transactions', (done) => {
       taxjarClient.listRefunds({
         'from_transaction_date': '2015/05/01',
-        'to_transaction_date': '2015/05/31'
+        'to_transaction_date': '2015/05/31',
+        'provider': 'api'
       }).then(res => {
         assert.deepEqual(res, refundMock.LIST_REFUND_RES);
         done();
@@ -347,7 +352,8 @@ describe('TaxJar API', () => {
         taxjarClient.setApiConfig('apiUrl', process.env.TAXJAR_API_URL);
         taxjarClient.listRefunds({
           'from_transaction_date': '2015/05/01',
-          'to_transaction_date': '2015/05/31'
+          'to_transaction_date': '2015/05/31',
+          'provider': 'api'
         }).then(res => {
           assert.isOk(res.refunds);
           done();
@@ -356,7 +362,7 @@ describe('TaxJar API', () => {
     }
 
     it('shows a refund transaction', (done) => {
-      taxjarClient.showRefund('321').then(res => {
+      taxjarClient.showRefund('321', {provider: 'api'}).then(res => {
         assert.deepEqual(res, refundMock.SHOW_REFUND_RES);
         done();
       });
@@ -365,7 +371,7 @@ describe('TaxJar API', () => {
     if (process.env.TAXJAR_API_URL) {
       it('showRefund returns successful response in sandbox', (done) => {
         taxjarClient.setApiConfig('apiUrl', process.env.TAXJAR_API_URL);
-        taxjarClient.showRefund('321').then(res => {
+        taxjarClient.showRefund('321', {provider: 'api'}).then(res => {
           assert.isOk(res.refund);
           done();
         });
@@ -377,6 +383,7 @@ describe('TaxJar API', () => {
         'transaction_id': '123',
         'transaction_date': '2015/05/14',
         'transaction_reference_id': '123',
+        'provider': 'api',
         'to_country': 'US',
         'to_zip': '90002',
         'to_state': 'CA',
@@ -407,6 +414,7 @@ describe('TaxJar API', () => {
           'transaction_id': '123',
           'transaction_date': '2015/05/14',
           'transaction_reference_id': '123',
+          'provider': 'api',
           'to_country': 'US',
           'to_zip': '90002',
           'to_state': 'CA',
@@ -475,7 +483,7 @@ describe('TaxJar API', () => {
     }
 
     it('deletes a refund transaction', (done) => {
-      taxjarClient.deleteRefund('321').then(res => {
+      taxjarClient.deleteRefund('321', {provider: 'api'}).then(res => {
         assert.deepEqual(res, refundMock.DELETE_REFUND_RES);
         done();
       });
@@ -484,7 +492,7 @@ describe('TaxJar API', () => {
     if (process.env.TAXJAR_API_URL) {
       it('deleteRefund returns successful response in sandbox', (done) => {
         taxjarClient.setApiConfig('apiUrl', process.env.TAXJAR_API_URL);
-        taxjarClient.deleteRefund('321').then(res => {
+        taxjarClient.deleteRefund('321', {provider: 'api'}).then(res => {
           assert.isOk(res.refund);
           done();
         });


### PR DESCRIPTION
This PR implements the new `provider` param, which currently adds marketplace exemption support for Amazon, eBay, Etsy, and Walmart transactions. `provider` defaults to `api`.

The `provider` param will be supported in methods:

- `listOrders`
- `showOrder`
- `createOrder`
- `deleteOrder`
- `listRefunds`
- `showRefund`
- `createRefund`
- `deleteRefund`