### PR TITLE
Add error message to proxied error

### DIFF
--- a/lib/util/request.ts
+++ b/lib/util/request.ts
@@ -27,7 +27,9 @@ export default class Request {
       RequestPromise(options.uri, options).then(result => {
         resolve(result);
       }).catch(result => {
-        let proxiedError = new (<any>Error)();
+        let proxiedError = new (<any>Error)(
+          `TaxJar: ${result.error.error} - ${result.error.detail}`
+        );
         proxiedError.error = result.error.error;
         proxiedError.detail = result.error.detail;
         proxiedError.status = result.statusCode;

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -40,6 +40,7 @@ describe('TaxJar API', () => {
 
       taxjarClient.categories().catch(err => {
         assert.equal(err instanceof Error, true);
+        assert.equal(err.message, `TaxJar: ${err.error} - ${err.detail}`);
         assert.equal(err.error, 'Unauthorized');
         assert.equal(err.detail, "Not authorized for route 'GET /v2/categories'");
         assert.equal(err.status, 401);


### PR DESCRIPTION
To aid in debugging and error handling, errors will now include a `message` in the format `` `TaxJar: ${error} - ${detail}` ``.

For example, assuming a `401 - Unauthorized` error:

```js
client.categories().catch(err => {
  console.assert(err.message === "TaxJar: Unauthorized - Not authorized for route 'GET /v2/categories'");
  console.assert(err.error === 'Unauthorized');
  console.assert(err.detail === "Not authorized for route 'GET /v2/categories'");
  console.assert(err.status === 401);
});
```

See #33 for further discussion.