### PR TITLE
Add support for order-level exemptions via `exemption_type` param

### DIFF
--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -128,6 +128,7 @@ export namespace TaxjarTypes {
     shipping: number,
     sales_tax: number,
     customer_id?: string,
+    exemption_type?: string,
     line_items?: LineItem[]
   }
 

--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -106,6 +106,7 @@ export namespace TaxjarTypes {
     shipping?: number,
     sales_tax?: number,
     customer_id?: string,
+    exemption_type?: string,
     line_items?: LineItem[]
   }
 

--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -85,6 +85,7 @@ export namespace TaxjarTypes {
     shipping: number,
     sales_tax: number,
     customer_id?: string,
+    exemption_type?: string,
     line_items?: LineItem[]
   }
 

--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -57,6 +57,7 @@ export namespace TaxjarTypes {
     amount?: number,
     shipping: number,
     customer_id?: string,
+    exemption_type?: string,
     nexus_addresses?: NexusAddress[],
     line_items?: TaxLineItem[]
   }

--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -150,6 +150,7 @@ export namespace TaxjarTypes {
     shipping?: number,
     sales_tax?: number,
     customer_id?: string,
+    exemption_type?: string,
     line_items?: LineItem[]
   }
 

--- a/test/mocks/orders.js
+++ b/test/mocks/orders.js
@@ -16,6 +16,7 @@ const SHOW_ORDER_RES = {
     "transaction_id": "123",
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
+    "exemption_type": "non_exempt",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",

--- a/test/mocks/refunds.js
+++ b/test/mocks/refunds.js
@@ -17,6 +17,7 @@ const SHOW_REFUND_RES = {
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
     "transaction_reference_id": "123",
+    "exemption_type": "non_exempt",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",

--- a/test/mocks/taxes.js
+++ b/test/mocks/taxes.js
@@ -11,6 +11,7 @@ const TAX_RES = {
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "exemption_type": "non_exempt",
     "breakdown": {
       "shipping": {
         "state_amount": 0.11,
@@ -57,7 +58,8 @@ nock(TEST_API_HOST)
     to_zip: '07446',
     to_state: 'NJ',
     amount: 16.5,
-    shipping: 1.5
+    shipping: 1.5,
+    exemption_type: 'non_exempt'
   })
   .reply(200, TAX_RES);
 

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -279,6 +279,7 @@ describe('TaxJar API', () => {
         'transaction_id': '123',
         'amount': 16.5,
         'shipping': 1.5,
+        'exemption_type': 'non_exempt',
         'line_items': [
           {
             'quantity': 1,
@@ -302,6 +303,7 @@ describe('TaxJar API', () => {
           'transaction_id': '123',
           'amount': 16.5,
           'shipping': 1.5,
+          'exemption_type': 'non_exempt',
           'line_items': [
             {
               'quantity': 1,

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -227,6 +227,7 @@ describe('TaxJar API', () => {
         'amount': 16.5,
         'shipping': 1.5,
         'sales_tax': 0.95,
+        'exemption_type': 'non_exempt',
         'line_items': [
           {
             'quantity': 1,
@@ -256,6 +257,7 @@ describe('TaxJar API', () => {
           'amount': 16.5,
           'shipping': 1.5,
           'sales_tax': 0.95,
+          'exemption_type': 'non_exempt',
           'line_items': [
             {
               'quantity': 1,

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -143,7 +143,8 @@ describe('TaxJar API', () => {
         'to_zip': '07446',
         'to_state': 'NJ',
         'amount': 16.50,
-        'shipping': 1.5
+        'shipping': 1.5,
+        'exemption_type': 'non_exempt'
       }).then(res => {
         assert.deepEqual(res, taxMock.TAX_RES);
         done();
@@ -161,7 +162,8 @@ describe('TaxJar API', () => {
           'to_zip': '07446',
           'to_state': 'NJ',
           'amount': 16.50,
-          'shipping': 1.5
+          'shipping': 1.5,
+          'exemption_type': 'non_exempt'
         }).then(res => {
           assert.isOk(res.tax);
           done();

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -391,6 +391,7 @@ describe('TaxJar API', () => {
         'amount': 16.5,
         'shipping': 1.5,
         'sales_tax': 0.95,
+        'exemption_type': 'non_exempt',
         'line_items': [
           {
             'quantity': 1,
@@ -421,6 +422,7 @@ describe('TaxJar API', () => {
           'amount': 16.5,
           'shipping': 1.5,
           'sales_tax': 0.95,
+          'exemption_type': 'non_exempt',
           'line_items': [
             {
               'quantity': 1,

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -444,6 +444,7 @@ describe('TaxJar API', () => {
         'transaction_id': '321',
         'amount': 17,
         'shipping': 2.0,
+        'exemption_type': 'non_exempt',
         'line_items': [
           {
             'quantity': 1,
@@ -466,6 +467,7 @@ describe('TaxJar API', () => {
           'transaction_id': '321',
           'amount': 17,
           'shipping': 2.0,
+          'exemption_type': 'non_exempt',
           'line_items': [
             {
               'quantity': 1,


### PR DESCRIPTION
This change introduces an optional `exemption_type` parameter for:

- taxForOrder
- createOrder
- updateOrder
- createRefund
- updateRefund

The allowable values are: `government`, `wholesale`, `other`, and `non_exempt`.

With the exception of `non_exempt`, a request with one of these values indicates a transaction that is fully-exempt at the order level.

When also using the existing optional `customer_id` parameter, an `exemption_type` value of `non_exempt` specifies that a transaction belonging to an otherwise exempt customer be processed as taxable.

With the exception of `non_exempt`, when usage of the `customer_id` param qualifies the transaction as exempt, the customer's exemption type would be applied, rather than the `exemption_type` submitted in the request.