### PR TITLE
Ignore dist/.DS_Store when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "main": "dist/taxjar.js",
   "files": [
-    "dist/**"
+    "dist/**",
+    "!dist/.DS_Store"
   ],
   "types": "dist/taxjar.d.ts",
   "devDependencies": {


### PR DESCRIPTION
Just in case `.DS_Store` is generated in the `dist` folder, let's ignore it so it's not accidentally published.