### PR TITLE
Remove error type from promise success type

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,19 @@ client.taxForOrder({
 });
 ```
 
+In typescript, you may need to first verify the error type before handling:
+```ts
+client.taxForOrder(/* ... */)
+  .catch((err) => {
+    if (err instanceof Taxjar.Error) {
+      err.detail; // Error detail
+      err.status; // Error status code
+    } else {
+      // handle non-taxjar error
+    }
+  });
+```
+
 ## Testing
 
 ```

--- a/README.md
+++ b/README.md
@@ -513,7 +513,8 @@ client.taxForOrder({
 });
 ```
 
-In TypeTcript, you will need to first check the error's type before handling:
+In TypeScript, you may want to first check the error's type before handling:
+
 ```ts
 client.taxForOrder(/* ... */)
   .catch(err => {

--- a/README.md
+++ b/README.md
@@ -513,10 +513,10 @@ client.taxForOrder({
 });
 ```
 
-In typescript, you may need to first verify the error type before handling:
+In TypeTcript, you will need to first check the error's type before handling:
 ```ts
 client.taxForOrder(/* ... */)
-  .catch((err) => {
+  .catch(err => {
     if (err instanceof Taxjar.Error) {
       err.detail; // Error detail
       err.status; // Error status code

--- a/lib/taxjar.ts
+++ b/lib/taxjar.ts
@@ -1,10 +1,12 @@
 import request from './util/request';
-import TaxjarError, * as TaxjarTypes from './util/types';
+import * as TaxjarTypes from './util/types';
 
 class Taxjar {
   public static DEFAULT_API_URL = 'https://api.taxjar.com';
   public static SANDBOX_API_URL = 'https://api.sandbox.taxjar.com';
   public static API_VERSION = 'v2';
+
+  public static Error = TaxjarTypes.TaxjarError;
 
   private config: TaxjarTypes.Config;
   private request: TaxjarTypes.Request;
@@ -42,149 +44,149 @@ class Taxjar {
     this.request = request(this.config);
   }
 
-  categories(): Promise<TaxjarTypes.CategoriesRes | TaxjarError> {
+  categories(): Promise<TaxjarTypes.CategoriesRes> {
     return this.request.get({
       url: 'categories'
     });
   }
 
-  taxForOrder(params: TaxjarTypes.TaxParams): Promise<TaxjarTypes.TaxForOrderRes | TaxjarError> {
+  taxForOrder(params: TaxjarTypes.TaxParams): Promise<TaxjarTypes.TaxForOrderRes> {
     return this.request.post({
       url: 'taxes',
       params
     });
   }
 
-  listOrders(params?: TaxjarTypes.TransactionListParams): Promise<TaxjarTypes.ListOrdersRes | TaxjarError> {
+  listOrders(params?: TaxjarTypes.TransactionListParams): Promise<TaxjarTypes.ListOrdersRes> {
     return this.request.get({
       url: 'transactions/orders',
       params
     });
   }
 
-  showOrder(transactionId: string, params?: TaxjarTypes.TransactionShowParams): Promise<TaxjarTypes.ShowOrderRes | TaxjarError> {
+  showOrder(transactionId: string, params?: TaxjarTypes.TransactionShowParams): Promise<TaxjarTypes.ShowOrderRes> {
     return this.request.get({
       url: 'transactions/orders/' + transactionId,
       params
     });
   }
 
-  createOrder(params: TaxjarTypes.CreateOrderParams): Promise<TaxjarTypes.CreateOrderRes | TaxjarError> {
+  createOrder(params: TaxjarTypes.CreateOrderParams): Promise<TaxjarTypes.CreateOrderRes> {
     return this.request.post({
       url: 'transactions/orders',
       params
     });
   }
 
-  updateOrder(params: TaxjarTypes.UpdateOrderParams): Promise<TaxjarTypes.UpdateOrderRes | TaxjarError> {
+  updateOrder(params: TaxjarTypes.UpdateOrderParams): Promise<TaxjarTypes.UpdateOrderRes> {
     return this.request.put({
       url: 'transactions/orders/' + params.transaction_id,
       params
     });
   }
 
-  deleteOrder(transactionId: string, params?: TaxjarTypes.TransactionDeleteParams): Promise<TaxjarTypes.DeleteOrderRes | TaxjarError> {
+  deleteOrder(transactionId: string, params?: TaxjarTypes.TransactionDeleteParams): Promise<TaxjarTypes.DeleteOrderRes> {
     return this.request.delete({
       url: 'transactions/orders/' + transactionId,
       params
     });
   }
 
-  listRefunds(params?: TaxjarTypes.TransactionListParams): Promise<TaxjarTypes.ListRefundsRes | TaxjarError> {
+  listRefunds(params?: TaxjarTypes.TransactionListParams): Promise<TaxjarTypes.ListRefundsRes> {
     return this.request.get({
       url: 'transactions/refunds',
       params
     });
   }
 
-  showRefund(transactionId: string, params?: TaxjarTypes.TransactionShowParams): Promise<TaxjarTypes.ShowRefundRes | TaxjarError> {
+  showRefund(transactionId: string, params?: TaxjarTypes.TransactionShowParams): Promise<TaxjarTypes.ShowRefundRes> {
     return this.request.get({
       url: 'transactions/refunds/' + transactionId,
       params
     });
   }
 
-  createRefund(params: TaxjarTypes.CreateRefundParams): Promise<TaxjarTypes.CreateRefundRes | TaxjarError> {
+  createRefund(params: TaxjarTypes.CreateRefundParams): Promise<TaxjarTypes.CreateRefundRes> {
     return this.request.post({
       url: 'transactions/refunds',
       params
     });
   }
 
-  updateRefund(params: TaxjarTypes.UpdateRefundParams): Promise<TaxjarTypes.UpdateRefundRes | TaxjarError> {
+  updateRefund(params: TaxjarTypes.UpdateRefundParams): Promise<TaxjarTypes.UpdateRefundRes> {
     return this.request.put({
       url: 'transactions/refunds/' + params.transaction_id,
       params
     });
   }
 
-  deleteRefund(transactionId: string, params?: TaxjarTypes.TransactionDeleteParams): Promise<TaxjarTypes.DeleteRefundRes | TaxjarError> {
+  deleteRefund(transactionId: string, params?: TaxjarTypes.TransactionDeleteParams): Promise<TaxjarTypes.DeleteRefundRes> {
     return this.request.delete({
       url: 'transactions/refunds/' + transactionId,
       params
     });
   }
 
-  listCustomers(): Promise<TaxjarTypes.ListCustomersRes | TaxjarError> {
+  listCustomers(): Promise<TaxjarTypes.ListCustomersRes> {
     return this.request.get({
       url: 'customers'
     });
   }
 
-  showCustomer(customerId: string): Promise<TaxjarTypes.ShowCustomerRes | TaxjarError> {
+  showCustomer(customerId: string): Promise<TaxjarTypes.ShowCustomerRes> {
     return this.request.get({
       url: 'customers/' + customerId
     });
   }
 
-  createCustomer(params: TaxjarTypes.CustomerParams): Promise<TaxjarTypes.CreateCustomerRes | TaxjarError> {
+  createCustomer(params: TaxjarTypes.CustomerParams): Promise<TaxjarTypes.CreateCustomerRes> {
     return this.request.post({
       url: 'customers',
       params
     });
   }
 
-  updateCustomer(params: TaxjarTypes.CustomerParams): Promise<TaxjarTypes.UpdateCustomerRes | TaxjarError> {
+  updateCustomer(params: TaxjarTypes.CustomerParams): Promise<TaxjarTypes.UpdateCustomerRes> {
     return this.request.put({
       url: 'customers/' + params.customer_id,
       params
     });
   }
 
-  deleteCustomer(customerId: string): Promise<TaxjarTypes.DeleteCustomerRes | TaxjarError> {
+  deleteCustomer(customerId: string): Promise<TaxjarTypes.DeleteCustomerRes> {
     return this.request.delete({
       url: 'customers/' + customerId
     });
   }
 
-  ratesForLocation (zip: string, params?: TaxjarTypes.RateParams): Promise<TaxjarTypes.RatesForLocationRes | TaxjarError> {
+  ratesForLocation (zip: string, params?: TaxjarTypes.RateParams): Promise<TaxjarTypes.RatesForLocationRes> {
     return this.request.get({
       url: 'rates/' + zip,
       params
     });
   }
 
-  nexusRegions(): Promise<TaxjarTypes.NexusRegionsRes | TaxjarError> {
+  nexusRegions(): Promise<TaxjarTypes.NexusRegionsRes> {
     return this.request.get({
       url: 'nexus/regions'
     });
   }
 
-  validateAddress(params: TaxjarTypes.AddressParams): Promise<TaxjarTypes.ValidateAddressRes | TaxjarError> {
+  validateAddress(params: TaxjarTypes.AddressParams): Promise<TaxjarTypes.ValidateAddressRes> {
     return this.request.post({
       url: 'addresses/validate',
       params
     });
   }
 
-  validate(params: TaxjarTypes.ValidateParams): Promise<TaxjarTypes.ValidateRes | TaxjarError> {
+  validate(params: TaxjarTypes.ValidateParams): Promise<TaxjarTypes.ValidateRes> {
     return this.request.get({
       url: 'validation',
       params
     });
   }
 
-  summaryRates(): Promise<TaxjarTypes.SummaryRatesRes | TaxjarError> {
+  summaryRates(): Promise<TaxjarTypes.SummaryRatesRes> {
     return this.request.get({
       url: 'summary_rates'
     });

--- a/lib/util/request.ts
+++ b/lib/util/request.ts
@@ -1,14 +1,14 @@
 import * as requestPromise from 'request-promise-native';
-import TaxjarError, { Config, Request } from '../util/types';
+import { Config, Request, TaxjarError } from '../util/types';
 
-const proxyError = (result): TaxjarError => {
-  const proxiedError = new (<any>Error)(
-    `TaxJar: ${result.error.error} - ${result.error.detail}`
+const proxyError = (result): Promise<never> => {
+  return Promise.reject(
+    new TaxjarError(
+      result.error.error,
+      result.error.detail,
+      result.statusCode,
+    )
   );
-  proxiedError.error = result.error.error;
-  proxiedError.detail = result.error.detail;
-  proxiedError.status = result.statusCode;
-  throw proxiedError;
 };
 
 export default (config: Config): Request => {

--- a/lib/util/request.ts
+++ b/lib/util/request.ts
@@ -1,7 +1,7 @@
 import * as requestPromise from 'request-promise-native';
 import { Config, Request, TaxjarError } from '../util/types';
 
-const proxyError = (result): Promise<never> => {
+const proxyError = (result): never => {
   throw new TaxjarError(
     result.error.error,
     result.error.detail,

--- a/lib/util/request.ts
+++ b/lib/util/request.ts
@@ -2,12 +2,10 @@ import * as requestPromise from 'request-promise-native';
 import { Config, Request, TaxjarError } from '../util/types';
 
 const proxyError = (result): Promise<never> => {
-  return Promise.reject(
-    new TaxjarError(
-      result.error.error,
-      result.error.detail,
-      result.statusCode,
-    )
+  throw new TaxjarError(
+    result.error.error,
+    result.error.detail,
+    result.statusCode,
   );
 };
 

--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -25,7 +25,12 @@ export class TaxjarError extends Error {
     public detail: string,
     public status: number
   ) {
-    super(`TaxJar: ${error} - ${detail}`);
-    Object.setPrototypeOf(this, TaxjarError.prototype);
+    super(`${error} - ${detail}`);
   }
 }
+ 
+Object.defineProperty(TaxjarError.prototype, 'name', {
+  value: 'TaxjarError',
+  configurable: true,
+  writable: true
+});

--- a/lib/util/types.ts
+++ b/lib/util/types.ts
@@ -19,8 +19,13 @@ export interface Request {
   delete (options: RequestOptions): Promise<any>
 }
 
-export default interface TaxjarError extends Error {
-  error: string,
-  detail: string,
-  status: number
+export class TaxjarError extends Error {
+  constructor(
+    public error: string,
+    public detail: string,
+    public status: number
+  ) {
+    super(`TaxJar: ${error} - ${detail}`);
+    Object.setPrototypeOf(this, TaxjarError.prototype);
+  }
 }

--- a/test/mocks/errors.js
+++ b/test/mocks/errors.js
@@ -5,7 +5,7 @@ const nock = require('nock');
 const TEST_API_HOST = 'https://mockapi.taxjar.com';
 
 const CATEGORY_ERROR_RES = {
-  "message": "TaxJar: Unauthorized - Not authorized for route 'GET /v2/categories'",
+  "message": "Unauthorized - Not authorized for route 'GET /v2/categories'",
   "error": "Unauthorized",
   "detail": "Not authorized for route 'GET /v2/categories'",
   "status": 401

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -53,6 +53,7 @@ describe('TaxJar API', () => {
 
       return taxjarClient.categories().catch(err => {
         assert.instanceOf(err, Error);
+        assert.instanceOf(err, Taxjar.Error);
         assert.sameProps(err, errorMocks.CATEGORY_ERROR_RES);
       });
     });


### PR DESCRIPTION
Fixes #43

This also creates a native JS error type, that follows correct `instanceof` semantics.