### PR TITLE
Reject with TaxjarError only when error originates from the API

### DIFF
--- a/lib/util/request.ts
+++ b/lib/util/request.ts
@@ -3,6 +3,7 @@ import { Config, Request, TaxjarError } from '../util/types';
 
 const proxyError = (result): never => {
   const isTaxjarError = result.statusCode && result.error && result.error.error && result.error.detail;
+
   if (isTaxjarError) {
     throw new TaxjarError(
       result.error.error,
@@ -10,6 +11,7 @@ const proxyError = (result): never => {
       result.statusCode
     );
   }
+
   throw result;
 };
 

--- a/lib/util/request.ts
+++ b/lib/util/request.ts
@@ -2,11 +2,15 @@ import * as requestPromise from 'request-promise-native';
 import { Config, Request, TaxjarError } from '../util/types';
 
 const proxyError = (result): never => {
-  throw new TaxjarError(
-    result.error.error,
-    result.error.detail,
-    result.statusCode,
-  );
+  const isTaxjarError = result.statusCode && result.error && result.error.error && result.error.detail;
+  if (isTaxjarError) {
+    throw new TaxjarError(
+      result.error.error,
+      result.error.detail,
+      result.statusCode
+    );
+  }
+  throw result;
 };
 
 export default (config: Config): Request => {

--- a/test/mocks/errors.js
+++ b/test/mocks/errors.js
@@ -11,9 +11,22 @@ const CATEGORY_ERROR_RES = {
   "status": 401
 };
 
+const NEXUS_REGIONS_ERROR_RES = {
+  name: 'RequestError',
+  message: 'Error: Invalid URI "invalidApiUrl/v2/nexus/regions"'
+};
+
 nock(TEST_API_HOST)
   .matchHeader('Authorization', /Bearer.*/)
   .get('/v2/categories')
   .reply(401, CATEGORY_ERROR_RES);
 
-module.exports.CATEGORY_ERROR_RES = CATEGORY_ERROR_RES;
+nock('invalidApiUrl')
+  .matchHeader('Authorization', /Bearer.*/)
+  .get('/v2/nexus/regions')
+  .replyWithError(NEXUS_REGIONS_ERROR_RES);
+
+module.exports = {
+  CATEGORY_ERROR_RES,
+  NEXUS_REGIONS_ERROR_RES
+};

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -58,6 +58,17 @@ describe('TaxJar API', () => {
       });
     });
 
+    it('rejects promise on non-API error', () => {
+      const errorMocks = require('./mocks/errors');
+      taxjarClient.setApiConfig('apiUrl', 'invalidApiUrl');
+
+      return taxjarClient.nexusRegions().catch(err => {
+        assert.instanceOf(err, Error);
+        assert.notInstanceOf(err, Taxjar.Error);
+        assert.include(err, errorMocks.NEXUS_REGIONS_ERROR_RES);
+      });
+    });
+
     it('gets api config', () => {
       assert.equal(
         taxjarClient.getApiConfig('apiUrl'),


### PR DESCRIPTION
This PR fixes an issue where errors not directly related to the Sales Tax API (`RequestError`, for example) were improperly being converted to `TaxjarError`s.

For example, in issue #46 a customer received an error without any pertinent details:

```
{
  detail: undefined, 
  error: undefined, 
  message: undefined - undefined, 
  name: TaxjarError, 
  stack: 
  TaxjarError: undefined - undefined
      at proxyError (/home/node/app/node_modules/taxjar/dist/util/request.js:6:11), 
  status: undefined
}
```

After release, non-TaxjarErrors will be passed along to the consumer with no change in the original structure to avoid these unhelpful errors.