### PR TITLE
Add a custom user agent string to each request

### DIFF
--- a/lib/util/request.ts
+++ b/lib/util/request.ts
@@ -1,5 +1,8 @@
 import * as requestPromise from 'request-promise-native';
+
 import { Config, Request, TaxjarError } from '../util/types';
+
+const os = require('os');
 
 const proxyError = (result): never => {
   const isTaxjarError = result.statusCode && result.error && result.error.error && result.error.detail;
@@ -15,11 +18,19 @@ const proxyError = (result): never => {
   throw result;
 };
 
+const userAgent = `TaxJar/Node (${[
+  os.version && os.version() || process.platform,
+  os.arch(),
+  `${process.release.name} ${process.versions.node}`,
+  `OpenSSL/${process.versions.openssl}`
+].join('; ')}) taxjar-node/${require('../../package.json').version}`;
+
 export default (config: Config): Request => {
   const request = requestPromise.defaults({
     headers: Object.assign({}, config.headers || {}, {
       Authorization: `Bearer ${config.apiKey}`,
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'User-Agent': userAgent
     }),
     baseUrl: config.apiUrl,
     json: true

--- a/lib/util/request.ts
+++ b/lib/util/request.ts
@@ -18,19 +18,22 @@ const proxyError = (result): never => {
   throw result;
 };
 
-const userAgent = `TaxJar/Node (${[
-  os.version && os.version() || process.platform,
-  os.arch(),
-  `${process.release.name} ${process.versions.node}`,
-  `OpenSSL/${process.versions.openssl}`
-].join('; ')}) taxjar-node/${require('../../package.json').version}`;
+const getUserAgent = (): string => {
+  const platform = os.version && os.version() || process.platform;
+  const arch = os.arch();
+  const nodeVersion = `${process.release.name} ${process.versions.node}`;
+  const openSslVersion = `OpenSSL/${process.versions.openssl}`;
+  const pkgVersion = `taxjar-node/${require('../../package.json').version}`;
+
+  return `TaxJar/Node (${[platform, arch, nodeVersion, openSslVersion].join('; ')}) ${pkgVersion}`;
+}
 
 export default (config: Config): Request => {
   const request = requestPromise.defaults({
     headers: Object.assign({}, config.headers || {}, {
       Authorization: `Bearer ${config.apiKey}`,
       'Content-Type': 'application/json',
-      'User-Agent': userAgent
+      'User-Agent': getUserAgent()
     }),
     baseUrl: config.apiUrl,
     json: true

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -2,6 +2,7 @@
 
 const chai = require('chai');
 const chaiStuff = require('chai-stuff');
+const nock = require('nock');
 const Taxjar = require('../dist/taxjar');
 
 const rateMock = require('./mocks/rates');
@@ -79,6 +80,16 @@ describe('TaxJar API', () => {
     it('sets api config', () => {
       taxjarClient.setApiConfig('apiUrl', 'https://api.sandbox.taxjar.com');
       assert.equal(taxjarClient.getApiConfig('apiUrl'), 'https://api.sandbox.taxjar.com/v2/');
+    });
+
+    it('includes appropriate headers', () => {
+      nock(taxjarClient.getApiConfig('apiUrl'), {allowUnmocked: true}).get('/rates/12345').reply(function() {
+        assert.match(this.req.headers.authorization, /^Bearer \w+$/);
+        assert.equal(this.req.headers['content-type'], 'application/json');
+        assert.match(this.req.headers['user-agent'], /^TaxJar\/Node (.*) taxjar-node\/\d+\.\d+\.\d+$/);
+        return [200, {}];
+      });
+      return taxjarClient.ratesForLocation('12345');
     });
 
     it('sets custom headers via instantiation', () => {

--- a/test/taxjar.spec.js
+++ b/test/taxjar.spec.js
@@ -87,8 +87,10 @@ describe('TaxJar API', () => {
         assert.match(this.req.headers.authorization, /^Bearer \w+$/);
         assert.equal(this.req.headers['content-type'], 'application/json');
         assert.match(this.req.headers['user-agent'], /^TaxJar\/Node (.*) taxjar-node\/\d+\.\d+\.\d+$/);
+
         return [200, {}];
       });
+
       return taxjarClient.ratesForLocation('12345');
     });
 


### PR DESCRIPTION
To help debug technical issues, it's necessary to collect additional information about a user's server.

For that purpose, this PR adds a custom user agent string to each request, which includes the following information:

- Operating system
- Node version
- OpenSSL version
- Version of taxjar-node currently being used

Example UA string:
<img width="489" alt="Screen Shot 2020-03-19 at 8 54 11 AM" src="https://user-images.githubusercontent.com/26824724/77086644-4a091280-69bf-11ea-9afa-5223d8db3d3d.png">
