### PR TITLE
Export all paramTypes interfaces

### DIFF
--- a/lib/types/paramTypes.ts
+++ b/lib/types/paramTypes.ts
@@ -5,7 +5,7 @@ export interface RateParams {
   country?: string
 }
 
-interface NexusAddress {
+export interface NexusAddress {
   id?: string,
   country?: string,
   zip?: string,
@@ -14,7 +14,7 @@ interface NexusAddress {
   street?: string
 }
 
-interface TaxLineItem {
+export interface TaxLineItem {
   id?: string,
   quantity?: number,
   product_tax_code?: string,
@@ -22,7 +22,7 @@ interface TaxLineItem {
   discount?: number
 }
 
-interface LineItem extends TaxLineItem {
+export interface LineItem extends TaxLineItem {
   product_identifier?: string,
   description?: string,
   sales_tax?: number
@@ -148,7 +148,7 @@ export interface UpdateRefundParams {
   line_items?: LineItem[]
 }
 
-interface ExemptRegion {
+export interface ExemptRegion {
   country?: string,
   state?: string
 }


### PR DESCRIPTION
In my own projects, I need to transform our own data types into properties of Taxjar params, but these types aren't exported (namely `NexusAddress` and `TaxLineItem`) so we're having to redefine them in our own codebase. Exporting them here allows for you to control the actual type and less copy/paste fragility.